### PR TITLE
Fix: Window 환경에서 "Delete ␍" 에러 해결을 위한 .eslintrc 파일 업데이트

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,4 +25,10 @@
       },
     },
   },
+  "prettier/prettier": [
+    "error",
+    {
+      "endOfLine": "auto",
+    },
+  ],
 }


### PR DESCRIPTION
## 📌 관련 이슈
Window에서 "Delete ␍" 오류가 나오는 문제

## ✨ 과제 내용
- .eslintrc 파일의 Prettier 설정을 수정하여 줄 끝 문자 이슈 해결
- "endOfLine"을 "auto"로 설정하여 다양한 운영 체제에서의 호환성 개선
- 이 변경으로 "Delete `␍`" 오류가 해결됨
